### PR TITLE
Module boostrap required to use this library in GWT.

### DIFF
--- a/src/org/ssgwt/ssGwt.gwt.xml
+++ b/src/org/ssgwt/ssGwt.gwt.xml
@@ -1,0 +1,3 @@
+<module>
+    <inherits name="com.google.gwt.user.User"/>
+</module>


### PR DESCRIPTION
Module boostrap required to use this library in GWT.
