### PR TITLE
Fixed IE rendering issue on SSDatePicker

### DIFF
--- a/src/org/ssgwt/client/ui/datepicker/RangedCalendarView.java
+++ b/src/org/ssgwt/client/ui/datepicker/RangedCalendarView.java
@@ -362,8 +362,8 @@ public class RangedCalendarView extends CalendarView {
                     divChild.addClassName(css().wrap("DayValue"));
                     getElement().appendChild(divChild);
                 }
-                DOM.setInnerText(divChild, value);
                 DOM.setInnerText(getElement(), "");
+                DOM.setInnerText(divChild, value);
                 DOM.appendChild(getElement(), divChild);
             }
 


### PR DESCRIPTION
Fixed an issue where the day numbers on the SSDatePicker didn't render on the
IE because IE renders a div inside a cell and sees the div as the cell. The
SSDatePicker removed all content after the div was update on IE.

issue #49
