### PR TITLE
Updated ssGWT-Lib build file to include piriti as a dependency

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -6,6 +6,7 @@
 
 	<path id="project.class.path">
 		<pathelement location="/opt/gwt/gwt-user.jar"/>
+		<fileset dir="war/WEB-INF/lib" includes="*.jar"/>
 		<fileset dir="/opt/gwt" includes="gwt-dev*.jar"/>
 	</path>
 


### PR DESCRIPTION
Updated ssGWT-Lib build file to include piriti as a dependency

issue A24Group/Triage#437
