### PR TITLE
Fixed the LeftMenuBar's setLeftMenuBar function

### DIFF
--- a/src/org/ssgwt/client/ui/menu/LeftMenuBar.java
+++ b/src/org/ssgwt/client/ui/menu/LeftMenuBar.java
@@ -153,6 +153,7 @@ public class LeftMenuBar extends Composite {
      * @since 09 July 2012
      */
     public void setLeftMenuBar(List<MenuItem> menuItems) {
+        leftMenuBarContainer.clear();
         if (menuItems != null) {
             List<MenuItem> sorted = new ArrayList<MenuItem>();
             int max = 0;


### PR DESCRIPTION
Fixed the LeftMenuBar's setLeftMenuBar function to clear the left menu before
adding new items to the left menu.

issue A24Group/Triage#773
