### PR TITLE
Fix the hide place holder fuction

### DIFF
--- a/src/org/ssgwt/client/ui/AdvancedTextbox.java
+++ b/src/org/ssgwt/client/ui/AdvancedTextbox.java
@@ -191,8 +191,8 @@ public class AdvancedTextbox extends TextBox implements AdvancedInputField<Strin
     public void hidePlaceholder() {
         if (super.getText().equals(this.getPlaceholderText())) {
             super.setText("");
-            super.removeStyleName(this.getPlaceholderStyleName());
         }
+        super.removeStyleName(this.getPlaceholderStyleName());
     }
 
     /**


### PR DESCRIPTION
No issue link to this commit

The place holder can now be removed if the text is not the same as the place holder.
