### PR TITLE
username must start with an alph num char

### DIFF
--- a/src/org/ssgwt/client/validation/validators/UsernameValidator.java
+++ b/src/org/ssgwt/client/validation/validators/UsernameValidator.java
@@ -34,7 +34,7 @@ public class UsernameValidator extends AbstractValidator implements ValidatorInt
     /**
      * The regular expression patterns string to be used to validate the value.
      */
-    private static final String USERNAME_PATTERN = "^[_A-Za-z0-9-]+(\\.[_A-Za-z0-9-]+)*";
+    private static final String USERNAME_PATTERN = "^[A-Za-z0-9]+(\\.|[_A-Za-z0-9-]+)*";
     
     /**
      * Default error message to use for validation


### PR DESCRIPTION
changed user name validator to start with at least an
alpha numeric character.

https://github.com/A24Group/Triage/issues/1291
