### PR TITLE
Fixed the getInnerElement function on the ImageButton

### DIFF
--- a/src/org/ssgwt/client/ui/ImageButton.java
+++ b/src/org/ssgwt/client/ui/ImageButton.java
@@ -63,6 +63,11 @@ public class ImageButton extends FocusPanel {
     private Element imageElement;
     
     /**
+     * The inner div that holds the image and the label
+     */
+    private Element innerElement;
+    
+    /**
      * Class constructor creates a button with the image on the left side
      * 
      * @param label - The label of the button
@@ -183,7 +188,7 @@ public class ImageButton extends FocusPanel {
      * @return the div inside the button
      */
     public Element getInnerElement() {
-        return DOM.getFirstChild(getElement());
+        return innerElement;
     }
     
     /**


### PR DESCRIPTION
Fixed issue in the ImageButton where the getInnerElement didn't work in
compiled mode.

issue A24Group/Triage#1933
