### PR TITLE
Fixed the styling issue for the datagrid on IE

### DIFF
--- a/src/org/ssgwt/client/ui/datagrid/SSDataGridStyle.css
+++ b/src/org/ssgwt/client/ui/datagrid/SSDataGridStyle.css
@@ -20,7 +20,6 @@
 
 /*Styling of the first column of the data grid*/
 .dataGridFirstColumn {
-    padding-left: 20px !Important;
     box-sizing: border-box;
     -moz-box-sizing: border-box;
     -webkit-box-sizing: border-box;
@@ -39,9 +38,18 @@
     float: right;
 }
 
+/*The styling applied if the data grid supports multi select*/
+@external .isMultiSelect;
+.isMultiSelect .dataGridFirstColumn > div {
+    margin-left: 20px;
+}
+
 /*Styling of the last column of the data grid*/
 .dataGridLastColumn {
-    padding-right: 5px;
+}
+
+.dataGridLastColumn > div{
+    margin-right: 5px;
     box-sizing: border-box;
     -moz-box-sizing: border-box;
     -webkit-box-sizing: border-box;
@@ -143,14 +151,12 @@
     white-space:nowrap;
     color: #777B88;
     padding-top: 4px;
-    padding-left: 22px;
-    overflow: hidden;
 }
 
 .dataGridCell > div {
     margin-top:-1px;
+    margin-left: 22px;
     white-space:nowrap;
-    overflow: hidden;
     text-overflow: clip;
 }
 
@@ -178,6 +184,7 @@
 .dataGridLastColumnHeader {
     border-right:1px solid #BDBFC5;
     border-radius: 0 3px 0 0;
+    box-sizing: border-box;
     -moz-border-radius: 0 3px 0 0;
     -webkit-border-radius: 0 3px 0 0;
 }
@@ -252,8 +259,9 @@
 }
 
 .dataGridHoveredRow td:first-child > div {
-      margin-left:-1px;
-      overflow: auto;
+    border-collapse: none;
+    margin-left: 19px !important;
+    overflow: auto;
 }
 
 /*Style applied to the row when hovered over*/


### PR DESCRIPTION
Fixed the styling issue for the datagrid on IE
This is the issue where the items jump to the
left when clicked on. To test:
Make sure all the datagrids still look and
functions as expected on all browsers

issue A24Group/Triage#2129
