### PR TITLE
Fixed the chrome windows datagrid bug

### DIFF
--- a/src/org/ssgwt/client/ui/datagrid/SSDataGridStyle.css
+++ b/src/org/ssgwt/client/ui/datagrid/SSDataGridStyle.css
@@ -38,6 +38,16 @@
     float: right;
 }
 
+/*
+This style is used to eliminate a windows 7 / windows 8 chrome bug
+It will set the already invisible scroll panel around the datagrid
+to not display at all, stopping it from interfering with the datagrid
+bottom items
+*/
+.isMultiSelect > div > div > div > div > div > div {
+    display: none;
+}
+
 /*The styling applied if the data grid supports multi select*/
 @external .isMultiSelect;
 .isMultiSelect .dataGridFirstColumn > div {


### PR DESCRIPTION
## Testing:

Make sure that all items (especially the last one) in the datagrids are still able to be selected. Test this with multiple amounts of items in a datagrid.

issue: A24Group/Triage#2536

@kkroese - I've tested this on my local machine at home but you must also test this at your home environment after it has been merged to confirm that all is working now. 

![staffshift](https://f.cloud.github.com/assets/1477827/484854/a9230738-b8e3-11e2-9916-792b059d1753.png)
