### PR TITLE
Added style to make the text overflow of the datagrid footer elips

### DIFF
--- a/src/org/ssgwt/client/ui/datagrid/SSDataGridStyle.css
+++ b/src/org/ssgwt/client/ui/datagrid/SSDataGridStyle.css
@@ -81,7 +81,13 @@ bottom items
     color: #4b4a4a;
     text-shadow: #ddf 1px 1px 0;
     overflow: hidden;
+    text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+.dataGridFooter > div {
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 /*Styling for the header of the data grid*/


### PR DESCRIPTION
The footers text overflow elips the same as a cell does

A24group/Triage#3817

Test
- Check this out
- Compile jar
- Copy jar to triage
- deploy gwt
- View a timesheet with the total expense longer that the length of the column. Make sure that the totals elips the same way as the cells
