### PR TITLE
Fix the scrollbars not working

### DIFF
--- a/src/org/ssgwt/client/ui/datagrid/SSDataGridStyle.css
+++ b/src/org/ssgwt/client/ui/datagrid/SSDataGridStyle.css
@@ -45,7 +45,7 @@ to not display at all, stopping it from interfering with the datagrid
 bottom items
 */
 .isMultiSelect > div > div > div > div > div > div {
-    display: none;
+    padding-bottom: 15px;
 }
 
 /*The styling applied if the data grid supports multi select*/


### PR DESCRIPTION
## WIP Do not merge

Added the first part of the fix, adding a small space
to the bottom of the full size datagrids therefore
allowing both scrollbars to be enabled, yet the bottom
one is not in the way as it is above the space. Only
problem still lies with embedded datagrids as the
size is fixed and does not apply the padding.

issue: A24Group/Triage#3766
