### PR TITLE
Fix issue where the time of a date was change when parsing string to date

### DIFF
--- a/src/org/ssgwt/share/i18n/impl/DateRecord.java
+++ b/src/org/ssgwt/share/i18n/impl/DateRecord.java
@@ -221,8 +221,9 @@ public class DateRecord extends SSDate {
 
     // Adjust time zone.
     if (this.tzOffset > Integer.MIN_VALUE) {
+      long timeStamp = date.getTime();
       date.setTimezoneOffset(this.tzOffset);
-      date.setTime(date.getTime());
+      date.setTime(timeStamp);
     }
 
     return true;


### PR DESCRIPTION
Fix issue where the time of a date was change if the offset didn't match the offest of the settings.

issue A24Group/Triage#3922
