### PR TITLE
Added the ability to set a custom width for each column.

### DIFF
--- a/src/org/ssgwt/client/ui/datagrid/SSDataGrid.java
+++ b/src/org/ssgwt/client/ui/datagrid/SSDataGrid.java
@@ -1149,7 +1149,7 @@ public class SSDataGrid<T extends AbstractMultiSelectObject> extends Composite
      * @since  25 July 2013
      * 
      * @param column - The column to set the width for
-     * @param width - The width in style format
+     * @param width - The width in style format (This can be any valid css mesurement)
      */
     public void setColumnWidth(Column<T, ?> column, String width) {
         dataGrid.setColumnWidth(column, width);


### PR DESCRIPTION
Added the ability to set a custom width for each column.
The width can be specified by any valid css width delimiter:
%, in, cm, mm, em, ex, pt, pc, px
## Testing
- Should not break
- Can only be checked with Triage changes

issue: A24Group/Triage#3905
