### PR TITLE
Removed default padding on generic popup

### DIFF
--- a/src/org/ssgwt/client/ui/popup/GenericPopup.css
+++ b/src/org/ssgwt/client/ui/popup/GenericPopup.css
@@ -15,7 +15,6 @@
 /* The style for the popup main panel */
 .hoverPopupContainer{
     background-color: #FFFFFF;
-    padding:          12px 15px 12px 12px;
     border:           1px solid #7E828E;
 }
 


### PR DESCRIPTION
Removed default padding on generic popup
This is not implemented anywhere, no testing required

issue #3720
