### PR TITLE
allow backticks in lastname A24Group#5076

### DIFF
--- a/src/org/ssgwt/client/validation/validators/StringRegexValidator.java
+++ b/src/org/ssgwt/client/validation/validators/StringRegexValidator.java
@@ -46,7 +46,7 @@ public class StringRegexValidator extends AbstractValidator implements
      * We allow a hyphen, apostrophe or space in the middle of the name.
      * Some accent and gravis symbols are also allowed.
      */
-    public static final String REGEX_NAME_PATTERN = "^[A-Za-zàáâäãåèéêëìíîïòóôöõøùúûüÿýñçčšžÀÁÂÄÃÅÈÉÊËÌÍÎÏÒÓÔÖÕØÙÚÛÜŸÝÑßÇŒÆČŠŽ∂ð]+([A-Z a-zàáâäãåèéêëìíîïòóôöõøùúûüÿýñçčšžÀÁÂÄÃÅÈÉÊËÌÍÎÏÒÓÔÖÕØÙÚÛÜŸÝÑßÇŒÆČŠŽ∂ð\\-']*[A-Za-zàáâäãåèéêëìíîïòóôöõøùúûüÿýñçčšžÀÁÂÄÃÅÈÉÊËÌÍÎÏÒÓÔÖÕØÙÚÛÜŸÝÑßÇŒÆČŠŽ∂ð]){0,}$";
+    public static final String REGEX_NAME_PATTERN = "^[A-Za-zàáâäãåèéêëìíîïòóôöõøùúûüÿýñçčšžÀÁÂÄÃÅÈÉÊËÌÍÎÏÒÓÔÖÕØÙÚÛÜŸÝÑßÇŒÆČŠŽ∂ð]+([A-Z a-zàáâäãåèéêëìíîïòóôöõøùúûüÿýñçčšžÀÁÂÄÃÅÈÉÊËÌÍÎÏÒÓÔÖÕØÙÚÛÜŸÝÑßÇŒÆČŠŽ∂ð\\-'`]*[A-Za-zàáâäãåèéêëìíîïòóôöõøùúûüÿýñçčšžÀÁÂÄÃÅÈÉÊËÌÍÎÏÒÓÔÖÕØÙÚÛÜŸÝÑßÇŒÆČŠŽ∂ð]){0,}$";
     
     /**
      * This regular expression is used to make sure that


### PR DESCRIPTION
A24Group/Triage#5076

After change your ssGwt-lib soft link run `cap a24deploy:gwt:compile` from your Triage.

Now try to create a candidate from agency context having backtick(`) in Last Name , it will be allowed now.
