### PR TITLE
when adding a month to a month with fewer days, overflowed into next month

### DIFF
--- a/src/org/ssgwt/client/ui/datepicker/CalendarUtil.java
+++ b/src/org/ssgwt/client/ui/datepicker/CalendarUtil.java
@@ -56,8 +56,9 @@ public class CalendarUtil {
      * Adds the given number of months to a date.
      * 
      * This method will add a number of months onto the current month. If the resultant month has fewer
-     * days, we will set the date to max day for that month. If the month has more days, the month is simply
-     * incremented by the requested number of months.
+     * days, we will set the date to max day for that month. If the calculated month has more days than the current
+     * date that has been passed into the method, the month is simply incremented by the requested number of months
+     * passed into the method.
      *
      * @param date the date
      * @param months number of months
@@ -82,10 +83,9 @@ public class CalendarUtil {
                     date.setDate(28);
                 }
             } else if (
-                date.getDate() == 31 && 
-                (resultMonth <= 6 && resultMonth % 2 != 0) || (resultMonth > 6 && resultMonth % 2 == 0)
+                date.getDate() == 31 && (resultMonth == 3 || resultMonth == 5 || resultMonth == 8 || resultMonth == 10)
             ) {
-                //Here we are dealing with calculations on months with 30 days
+                //Here we are dealing with calculations on months with max of 30 days
                 date.setDate(30);
             }
             


### PR DESCRIPTION
**rdy for review**
**rdy for merge**

when adding a month to a month with fewer days, overflowed into next month
Fix placed here will ensure that if the result month has fewer days
the months are still calculated as a month addition and not a number of days.

A24Group/Triage#5136
