### PR TITLE
Gwt listing pages - HtmlEncoded the the Value string.

### DIFF
--- a/src/org/ssgwt/client/ui/datagrid/column/SSTextCell.java
+++ b/src/org/ssgwt/client/ui/datagrid/column/SSTextCell.java
@@ -28,6 +28,7 @@ import com.google.gwt.event.shared.HasHandlers;
 import com.google.gwt.safehtml.client.SafeHtmlTemplates;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.Window;
 
 /**
@@ -187,6 +188,7 @@ public class SSTextCell<T> extends AbstractCell<String> implements HasHandlers {
      * This will create a label with text and a tooltip with the same text value
      *
      * @author Ruan Naude <nauderuan777@gmail.com>
+     * @author Saurabh Chawla <saurabh.chawla@a24group.com>
      * @since 14 March 2013
      *
      * @param context -The context the cell is in
@@ -198,7 +200,11 @@ public class SSTextCell<T> extends AbstractCell<String> implements HasHandlers {
         if (value == null) {
             value = "";
         }
+        
         String tooltip = value;
+        //html encoding the string
+        value = SafeHtmlUtils.fromString(value).asString();
+
         if (this.sDateDisplayTooltipFormat != null && this.sDateDisplayTooltipFormat != ""
             && this.sDateFormat != null && this.sDateFormat != "") {
             try {


### PR DESCRIPTION
A24Group/Triage#5165
## Ready for review, test
## Testing Instructions
- Login to staffshift navigated to each of the listing pages below.
- Try and add `<b> <di break it` to any text box you can find on add page and save the collection object by clicking on add/Create/save button.
- Navigate back to the same listing page and check that the datagrid shows the value for the fields you entered as `<b> <di break it`.
- If any of the page Does not support `<b> <di break it` as a value to the fields that are visible on the datagrid go in the database and update the collection where the data for that datagrid is stored and set the value of the field as `<b> <di break it`  and refresh the front end and verify.
- Perform the test for all the scenario listed below
## Testing Scenarios:

**Organisation Context**
- [x] Vacancy Listing
- [x] User Listing
- [x] Group listing
- [x] Site Listing
- [x] Ward Listing
- [x] Order Listing
- [x] Agencies listing
- [x] Attendance (timesheets) listing

**Agency Context**
- [x] Vacancy Listing
- [x] User Listing
- [x] Branch Listing
- [x] Candidate Listing
- [x] Group listing
- [x] Clients listing
- [x] Client Site listing
- [x] Agency Order listing
- [x] Attendance listing

**System Admin Context**
- [x] Organisation Listing 
- [x] Agency Listing
- [x] Candidate Listing
- [x] User Listing
- [x] Invite listing 
- [x] Ward Listing
- [x] Site Listing 

**Candidate Context**
- [x] Attendance listing
