### PR TITLE
Fixed date picker bug with value smaller than minimum date.

### DIFF
--- a/src/org/ssgwt/client/ui/datepicker/DateBox.java
+++ b/src/org/ssgwt/client/ui/datepicker/DateBox.java
@@ -523,7 +523,6 @@ public class DateBox extends Composite implements HasValue<SSDate>,
     private void setValue(SSDate oldDate, SSDate date, boolean fireEvents) {
         SSDate pickerDate = date;
         if (date != null && this.getDatePicker().getMinimumDate().getTime() > date.getTime()) {
-            System.out.println("It has been set");
             pickerDate = new SSDate(this.getDatePicker().getMinimumDate().getTime());
             pickerDate.setDate(this.getDatePicker().getMinimumDate().getDate() + 1);
         }

--- a/src/org/ssgwt/client/ui/datepicker/DatePicker.java
+++ b/src/org/ssgwt/client/ui/datepicker/DatePicker.java
@@ -683,24 +683,24 @@ public class DatePicker extends Composite implements
     }
 
     /**
-     * Setter for the minimum date
+     * Getter for the minimum date
      *
      * @author Johannes Gryffenberg <johannes.gryffenberg@gmail.com>
      * @since  11 March 2014
      *
-     * @param minimumDate The new minimum date
+     * @return The minimum date
      */
     public SSDate getMinimumDate() {
         return ((RangedCalendarView) getView()).getMinimumDate();
     }
 
     /**
-     * Setter for the maximum date
+     * Getter for the maximum date
      *
      * @author Johannes Gryffenberg <johannes.gryffenberg@gmail.com>
      * @since  11 March 2014
      *
-     * @param minimumDate The new maximum date
+     * @return The maximum date
      */
     public SSDate getMaximumDate() {
         return ((RangedCalendarView) getView()).getMaximumDate();


### PR DESCRIPTION
Update the date picker so show the correct month if the value is smaller than
the minimum allowed date.

see https://github.com/A24Group/Triage/pull/5494#issuecomment-37179961
issue A24Group/Triage#5422
