### PR TITLE
Dropdown input now allows no prompt.

### DIFF
--- a/src/org/ssgwt/client/ui/form/DropDownInputField.java
+++ b/src/org/ssgwt/client/ui/form/DropDownInputField.java
@@ -110,7 +110,9 @@ public abstract class DropDownInputField<T, ListItemType> extends ListBox implem
     public void setListBoxItems(List<ListItemType> data) {
          this.data = data;
          this.clear();
-         this.addItem(prompt, "");
+         if (prompt != null) {
+             this.addItem(prompt, "");
+         }
          for (ListItemType listItem : this.data) {
             this.dataMap.put(getListId(listItem), listItem);
             this.addItem(getListLabel(listItem), getListId(listItem));


### PR DESCRIPTION
Changed the Dropdown input to now hide the prompt if the value is equal to `null`.

issue: A24Group/Triage#5286
