### PR TITLE
Set the data grid range selector to 1-1 when there is no data to display.

### DIFF
--- a/src/org/ssgwt/client/ui/datagrid/SSDataGrid.java
+++ b/src/org/ssgwt/client/ui/datagrid/SSDataGrid.java
@@ -203,7 +203,12 @@ public class SSDataGrid<T extends AbstractMultiSelectObject> extends Composite
      * Variable to hold the previous range before the range is changed
      */
     private Range previousRange = new Range(0, 0);
-
+    
+    /**
+     * The default range to apply to an empty data grid.
+     */
+    private Range emptyDataGridRange = new Range(0, 0);
+    
     /**
      * Holds all the filters added to the datagrid
      */
@@ -354,6 +359,8 @@ public class SSDataGrid<T extends AbstractMultiSelectObject> extends Composite
             refresh();
         } else {
             noContentLabel.setVisible(true);
+            //No data to display so we reset the range selector 
+            dataGrid.setVisibleRange(emptyDataGridRange);
         }
 
         if (previousRange.equals(dataGrid.getVisibleRange())) {


### PR DESCRIPTION
Set the data grid range selector to 1-1 when there is no data to display.
## Ready for review, Ready for testing
#### Testing Instructions
- Testing applies to all GWT data grids.
- Go to any page of the data grid except for the first page and apply a filter that will return 0 results. The range selector should now be reset to "1-1"

Issue: https://github.com/A24Group/Triage/issues/6715
