### PR TITLE
Fix on date picker

### DIFF
--- a/src/org/ssgwt/client/i18n/SSDate.java
+++ b/src/org/ssgwt/client/i18n/SSDate.java
@@ -260,6 +260,21 @@ public class SSDate extends Date
             this.timeZoneOffset = this.timeZone.getOffset(this);
         }
     }
+    
+    /**
+     * This method will be used to reset the time to 00:00:00
+     * 
+     * @author Michael Barnard <michael.barnard@a24group.com>
+     * @since  21 July 2015
+     * 
+     * @return The instance of the ssdate with time reset
+     */
+    public SSDate resetTime() {
+        this.setHours(0);
+        this.setMinutes(0);
+        this.setSeconds(0);
+        return this;
+    }
 
     /**
      * Retrieves the time zone of the date

--- a/src/org/ssgwt/client/i18n/SSDate.java
+++ b/src/org/ssgwt/client/i18n/SSDate.java
@@ -267,13 +267,12 @@ public class SSDate extends Date
      * @author Michael Barnard <michael.barnard@a24group.com>
      * @since  21 July 2015
      * 
-     * @return The instance of the ssdate with time reset
+     * @return void
      */
-    public SSDate resetTime() {
+    public void resetTime() {
         this.setHours(0);
         this.setMinutes(0);
         this.setSeconds(0);
-        return this;
     }
 
     /**

--- a/src/org/ssgwt/client/ui/datecomponents/DateTimeComponent.java
+++ b/src/org/ssgwt/client/ui/datecomponents/DateTimeComponent.java
@@ -397,7 +397,24 @@ public class DateTimeComponent extends Composite {
         
         this.lastUsedDate = this.defaultSelectedDate;
         
-        startDateBox = new DateBox(startDatePicker, defaultSelectedDate, DEFAULT_FORMAT);
+        startDateBox = new DateBox(startDatePicker, defaultSelectedDate, DEFAULT_FORMAT) {
+            /**
+             * This function is overridden so that we can set the last used date as well
+             * 
+             * @author Michael Barnard <michael.barnard@a24group.com>
+             * @since  22 July 2015
+             * 
+             * @param date - The date that should be set in the date picker
+             * @param fireEvents - Whether or not to fire events when the value is set
+             * 
+             * @return void
+             */
+            @Override
+            public void setValue(SSDate date, boolean fireEvents) {
+                super.setValue(date, fireEvents);
+                lastUsedDate = date;
+            }
+        };
         startDateBox.getTextBox().setReadOnly(true);
         startDateBox.addValueChangeHandler(
             new ValueChangeHandler<SSDate>() {
@@ -455,7 +472,24 @@ public class DateTimeComponent extends Composite {
         
         this.lastUsedEndDate = getShiftMinDate();
         
-        endDateBox = new DateBox(endDatePicker, getShiftMinDate(), DEFAULT_FORMAT);
+        endDateBox = new DateBox(endDatePicker, getShiftMinDate(), DEFAULT_FORMAT) {
+            /**
+             * This function is overridden so that we can set the last used date as well
+             * 
+             * @author Michael Barnard <michael.barnard@a24group.com>
+             * @since  22 July 2015
+             * 
+             * @param date - The date that should be set in the date picker
+             * @param fireEvents - Whether or not to fire events when the value is set
+             * 
+             * @return void
+             */
+            @Override
+            public void setValue(SSDate date, boolean fireEvents) {
+                super.setValue(date, fireEvents);
+                lastUsedEndDate = date;
+            }
+        };
         endDateBox.getTextBox().setReadOnly(true);
         endDateBox.addValueChangeHandler(
             new ValueChangeHandler<SSDate>() {
@@ -656,7 +690,7 @@ public class DateTimeComponent extends Composite {
         // Get the new date without time
         SSDate currentDate = date;
         currentDate.resetTime();
-
+        
         // Execute only if the dates are different
         if (!currentDate.equals(previousDate)) {
             this.lastUsedDate = date;

--- a/src/org/ssgwt/client/ui/datecomponents/DateTimeComponent.java
+++ b/src/org/ssgwt/client/ui/datecomponents/DateTimeComponent.java
@@ -204,6 +204,11 @@ public class DateTimeComponent extends Composite {
      * The date is selected by default
      */
     private final SSDate defaultSelectedDate;
+    
+    /**
+     * The date that was previously selected by the component
+     */
+    private SSDate lastUsedDate;
 
     /**
      * The last end date
@@ -377,6 +382,8 @@ public class DateTimeComponent extends Composite {
 
         this.defaultSelectedDate.setSeconds(0);
         this.defaultSelectedDate.setMinutes(roundUpTime(defaultSelectedDate.getMinutes()));
+        
+        this.lastUsedDate = this.defaultSelectedDate;
 
         this.maxShiftTime = maxShiftTime;
         this.minShiftTime = minShiftTime;
@@ -634,17 +641,26 @@ public class DateTimeComponent extends Composite {
      * @param date - The new date selected
      */
     private void onStartDateBoxValueChange(SSDate date) {
-        startTimePicker.setDate(date);
 
-        endDatePicker.setMinimumDate(getMinEndDate(getShiftMinDate()));
-        endDatePicker.setMaximumDate(getMaxEndDate(getShiftMaxDate()));
+        SSDate previousDate = this.lastUsedDate;
+        previousDate.resetTime();
 
-        endDateBox.setValue(getShiftMinDate());
-        endTimePicker.setDateTime(getShiftMinDate());
+        SSDate currentDate = date;
+        currentDate.resetTime();
 
-        endTimePicker.setMinDate(getShiftMinDate());
-        endTimePicker.setMaxDate(getShiftMaxDate());
-        totalTime.setText(getShiftTimeDiff(startTimePicker.getDateTime(), endTimePicker.getDateTime()));
+        if (!currentDate.equals(date)) {
+            startTimePicker.setDate(date);
+
+            endDatePicker.setMinimumDate(getMinEndDate(getShiftMinDate()));
+            endDatePicker.setMaximumDate(getMaxEndDate(getShiftMaxDate()));
+
+            endDateBox.setValue(getShiftMinDate());
+            endTimePicker.setDateTime(getShiftMinDate());
+
+            endTimePicker.setMinDate(getShiftMinDate());
+            endTimePicker.setMaxDate(getShiftMaxDate());
+            totalTime.setText(getShiftTimeDiff(startTimePicker.getDateTime(), endTimePicker.getDateTime()));
+        }
     }
 
     /**

--- a/src/org/ssgwt/client/ui/datecomponents/DateTimeComponent.java
+++ b/src/org/ssgwt/client/ui/datecomponents/DateTimeComponent.java
@@ -209,6 +209,11 @@ public class DateTimeComponent extends Composite {
      * The date that was previously selected by the component
      */
     private SSDate lastUsedDate;
+    
+    /**
+     * The end date that was previously selected by the component
+     */
+    private SSDate lastUsedEndDate;
 
     /**
      * The last end date
@@ -383,15 +388,15 @@ public class DateTimeComponent extends Composite {
         this.defaultSelectedDate.setSeconds(0);
         this.defaultSelectedDate.setMinutes(roundUpTime(defaultSelectedDate.getMinutes()));
         
-        this.lastUsedDate = this.defaultSelectedDate;
-
         this.maxShiftTime = maxShiftTime;
         this.minShiftTime = minShiftTime;
 
         // The date picker for the start date
         startDatePicker = new SSDatePicker(this.minDate, this.maxDate);
         startDatePicker.setStyleName(dtPickerSizeStyle);
-
+        
+        this.lastUsedDate = this.defaultSelectedDate;
+        
         startDateBox = new DateBox(startDatePicker, defaultSelectedDate, DEFAULT_FORMAT);
         startDateBox.getTextBox().setReadOnly(true);
         startDateBox.addValueChangeHandler(
@@ -447,7 +452,9 @@ public class DateTimeComponent extends Composite {
 
         endDatePicker = new SSDatePicker(getMinEndDate(getShiftMinDate()), getMaxEndDate(getShiftMaxDate()));
         endDatePicker.setStyleName(dtPickerSizeStyle);
-
+        
+        this.lastUsedEndDate = getShiftMinDate();
+        
         endDateBox = new DateBox(endDatePicker, getShiftMinDate(), DEFAULT_FORMAT);
         endDateBox.getTextBox().setReadOnly(true);
         endDateBox.addValueChangeHandler(
@@ -642,13 +649,17 @@ public class DateTimeComponent extends Composite {
      */
     private void onStartDateBoxValueChange(SSDate date) {
 
+        // Get the previous date without time
         SSDate previousDate = this.lastUsedDate;
         previousDate.resetTime();
 
+        // Get the new date without time
         SSDate currentDate = date;
         currentDate.resetTime();
 
-        if (!currentDate.equals(date)) {
+        // Execute only if the dates are different
+        if (!currentDate.equals(previousDate)) {
+            this.lastUsedDate = date;
             startTimePicker.setDate(date);
 
             endDatePicker.setMinimumDate(getMinEndDate(getShiftMinDate()));
@@ -673,9 +684,21 @@ public class DateTimeComponent extends Composite {
      * @param date - The new date selected
      */
     private void onEndDateBoxValueChange(SSDate date) {
-        endTimePicker.setDateTime(getShiftMinDate());
-        endTimePicker.setDate(date);
-        totalTime.setText(getShiftTimeDiff(startTimePicker.getDateTime(), endTimePicker.getDateTime()));
+        // Get the previous date without time
+        SSDate previousDate = this.lastUsedEndDate;
+        previousDate.resetTime();
+
+        // Get the new date without time
+        SSDate currentDate = date;
+        currentDate.resetTime();
+
+        // Execute only if the dates are different
+        if (!currentDate.equals(previousDate)) {
+            this.lastUsedEndDate = date;
+            endTimePicker.setDateTime(getShiftMinDate());
+            endTimePicker.setDate(date);
+            totalTime.setText(getShiftTimeDiff(startTimePicker.getDateTime(), endTimePicker.getDateTime()));
+        }
     }
 
     /**


### PR DESCRIPTION
### Ready for Review, Not ready for Testing

This branch fixes a bug on the datetime picker that causes it to
automatically reload when focus is lost, even if the date did not
change. This reload should only happen when the date changes

**Issue:** A24Group/Triage#7941